### PR TITLE
Fixes #39: by updating deprecated discovery URL

### DIFF
--- a/luminance/views/setup.py
+++ b/luminance/views/setup.py
@@ -147,7 +147,7 @@ class Setup(Gtk.Assistant):
 
     def search(self, cb):
         try:
-            data = requests.get('https://www.meethue.com/api/nupnp').json()
+            data = requests.get('https://discovery.meethue.com/').json()
 
             if not data:
                 raise ValueError('No bridges registered with Philips')


### PR DESCRIPTION
As described here: https://developers.meethue.com/news/,  www.meethue.com/api/nupnp has
been deprecated in favor of https://discovery.meethue.com and stopped
working on the 1st of July 2019.